### PR TITLE
Fast guid generation

### DIFF
--- a/Vostok.Commons.Threading.Tests/GuidGenerator_Tests.cs
+++ b/Vostok.Commons.Threading.Tests/GuidGenerator_Tests.cs
@@ -37,12 +37,12 @@ namespace Vostok.Commons.Threading.Tests
             const int tasksCount = 10;
             const int guidsInTask = 100_000;
 
-            var barrier = new ManualResetEvent(false);
+            var barrier = new Barrier(tasksCount);
             var tasks = new Task<HashSet<Guid>>[tasksCount];
             for (var i = 0; i < tasksCount; i++)
                 tasks[i] = Task.Run(() =>
                 {
-                    barrier.WaitOne();
+                    barrier.SignalAndWait();
                     var guids = new HashSet<Guid>();
                     for (var j = 0; j < guidsInTask; j++)
                         guids.Add(GuidGenerator.GenerateNotCryptoQualityGuid());
@@ -50,7 +50,6 @@ namespace Vostok.Commons.Threading.Tests
                     return guids;
                 });
 
-            barrier.Set();
             Task.WhenAll(tasks).GetAwaiter().GetResult();
 
             var allGuids = tasks.Aggregate(new HashSet<Guid>(),

--- a/Vostok.Commons.Threading.Tests/GuidGenerator_Tests.cs
+++ b/Vostok.Commons.Threading.Tests/GuidGenerator_Tests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Vostok.Commons.Threading.Tests
+{
+    [TestFixture]
+    internal class GuidGenerator_Tests
+    {
+        [Test]
+        public void Generated_Guids_Should_Be_Unique()
+        {
+            const int count = 10_000;
+            var guids = new HashSet<Guid>();
+            for (var i = 0; i < count; i++)
+                guids.Add(GuidGenerator.GenerateNotCryptoQualityGuid());
+
+            guids.Count.Should().Be(count);
+        }
+
+        [Test]
+        public void SmokeTest_Multithreading_Safety()
+        {
+            const int tasksCount = 10;
+            const int guidsInTask = 1000;
+
+            var tasks = new Task<HashSet<Guid>>[tasksCount];
+            for (var i = 0; i < tasksCount; i++)
+                tasks[i] = Task.Run(() =>
+                {
+                    var guids = new HashSet<Guid>();
+                    for (var j = 0; j < guidsInTask; j++)
+                        guids.Add(GuidGenerator.GenerateNotCryptoQualityGuid());
+
+                    return guids;
+                });
+            Task.WhenAll(tasks).GetAwaiter().GetResult();
+
+            var allGuids = tasks.Aggregate(new HashSet<Guid>(),
+                (s, t) =>
+                {
+                    foreach (var guid in t.Result)
+                    {
+                        s.Add(guid);
+                    }
+
+                    return s;
+                });
+
+            allGuids.Count.Should().Be(tasksCount * guidsInTask);
+        }
+    }
+}

--- a/Vostok.Commons.Threading.Tests/GuidGenerator_Tests.cs
+++ b/Vostok.Commons.Threading.Tests/GuidGenerator_Tests.cs
@@ -11,6 +11,15 @@ namespace Vostok.Commons.Threading.Tests
     internal class GuidGenerator_Tests
     {
         [Test]
+        [Explicit]
+        public void Print_Generated_Guids()
+        {
+            const int count = 100;
+            for (var i = 0; i < count; i++)
+                Console.WriteLine(GuidGenerator.GenerateNotCryptoQualityGuid());
+        }
+
+        [Test]
         public void Generated_Guids_Should_Be_Unique()
         {
             const int count = 10_000;

--- a/Vostok.Commons.Threading/GuidGenerator.cs
+++ b/Vostok.Commons.Threading/GuidGenerator.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace Vostok.Commons.Threading
+{
+    [PublicAPI]
+    internal static class GuidGenerator
+    {
+        public static unsafe Guid GenerateNotCryptoQualityGuid()
+        {
+            var bytes = stackalloc byte[16];
+            var dst = bytes;
+
+            var random = ThreadSafeRandom.ObtainThreadStaticRandom();
+            for (var i = 0; i < 4; i++)
+            {
+                *(int*)dst = random.Next();
+                dst += 4;
+            }
+
+            return *(Guid*)bytes;
+        }
+    }
+}

--- a/Vostok.Commons.Threading/ThreadSafeRandom.cs
+++ b/Vostok.Commons.Threading/ThreadSafeRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 namespace Vostok.Commons.Threading
@@ -58,6 +59,10 @@ namespace Vostok.Commons.Threading
             return NextDouble() <= 0.5;
         }
 
+        /// <summary>
+        /// Be careful! This method returns an instance of the class <see cref="Random"/> with <see cref="ThreadStaticAttribute"/> attribute. It is safe to use this instance only in a synchronous block of code, such as a loop.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Random ObtainThreadStaticRandom() => ObtainRandom();
 
         private static Random ObtainRandom()

--- a/Vostok.Commons.Threading/ThreadSafeRandom.cs
+++ b/Vostok.Commons.Threading/ThreadSafeRandom.cs
@@ -58,6 +58,8 @@ namespace Vostok.Commons.Threading
             return NextDouble() <= 0.5;
         }
 
+        public static Random ObtainThreadStaticRandom() => ObtainRandom();
+
         private static Random ObtainRandom()
         {
             return random ?? (random = new Random(Guid.NewGuid().GetHashCode()));

--- a/Vostok.Commons.Threading/Vostok.Commons.Threading.csproj
+++ b/Vostok.Commons.Threading/Vostok.Commons.Threading.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>7.2</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>0.1.2</VersionPrefix>
@@ -20,11 +21,5 @@
     <PackageLicenseUrl>https://github.com/vostok/commons.threading/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>vostok vostok.commons</PackageTags>
     <RepositoryUrl>https://github.com/vostok/commons.threading</RepositoryUrl>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/Vostok.Commons.Threading/Vostok.Commons.Threading.csproj
+++ b/Vostok.Commons.Threading/Vostok.Commons.Threading.csproj
@@ -21,4 +21,10 @@
     <PackageTags>vostok vostok.commons</PackageTags>
     <RepositoryUrl>https://github.com/vostok/commons.threading</RepositoryUrl>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is a known fact that Guid generation on Linux is VERY slow.
GenerateNotCryptoQualityGuid is a fast implementation of creating Guid. But it can't be used for cryptographic purposes.

```
Linux:
|                       Method |        Mean |     Error |    StdDev |         Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |------------:|----------:|----------:|------------:|------:|------:|------:|----------:|
|                  GuidNewGuid | 1,293.91 ns | 25.204 ns | 36.147 ns | 1,361.15 ns |     - |     - |     - |         - |
| GenerateNotCryptoQualityGuid |    56.45 ns |  1.168 ns |  2.046 ns |    61.85 ns |     - |     - |     - |         - |

Windows:
|                       Method |     Mean |    Error |   StdDev |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
|                  GuidNewGuid | 80.71 ns | 1.215 ns | 1.137 ns | 82.53 ns |     - |     - |     - |         - |
| GenerateNotCryptoQualityGuid | 43.73 ns | 0.588 ns | 0.550 ns | 44.68 ns |     - |     - |     - |         - |
```