### PR TITLE
Increase GuidGenerator speed under net6.0 target

### DIFF
--- a/Vostok.Commons.Threading.Tests/GuidGenerator_Benchmarks.cs
+++ b/Vostok.Commons.Threading.Tests/GuidGenerator_Benchmarks.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Running;
+using NUnit.Framework;
+
+namespace Vostok.Commons.Threading.Tests
+{
+    [TestFixture]
+    public class GuidGenerator_Benchmarks
+    {
+        [Test]
+        public void RunBenchmark()
+        {
+            BenchmarkRunner.Run<GuidGenerator_Benchmarks>(
+                DefaultConfig.Instance
+                    .AddDiagnoser(MemoryDiagnoser.Default)
+                    .WithOption(ConfigOptions.DisableOptimizationsValidator, true));
+        }
+
+        [Benchmark]
+        public Guid GuidNewGuid()
+        {
+            return Guid.NewGuid();
+        }
+
+        [Benchmark]
+        public Guid Generate()
+        {
+            return GuidGenerator.GenerateNotCryptoQualityGuid();
+        }
+
+        /*
+// * Summary *
+
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1415 (21H1/May2021Update)
+Intel Core i7-4771 CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
+.NET SDK=6.0.101
+  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
+  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
+
+
+|      Method |     Mean |    Error |   StdDev | Allocated |
+|------------ |---------:|---------:|---------:|----------:|
+| GuidNewGuid | 76.10 ns | 0.623 ns | 0.552 ns |         - |
+|    Generate | 42.97 ns | 0.150 ns | 0.133 ns |         - |
+         */
+    }
+}

--- a/Vostok.Commons.Threading.Tests/LifoSemaphore_Tests_Performance.cs
+++ b/Vostok.Commons.Threading.Tests/LifoSemaphore_Tests_Performance.cs
@@ -4,8 +4,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.InProcess;
 using NUnit.Framework;
 
 namespace Vostok.Commons.Threading.Tests
@@ -24,9 +25,10 @@ namespace Vostok.Commons.Threading.Tests
         [Explicit]
         public void Benchmark_single_threaded_speed_vs_SemaphoreSlim()
         {
-            BenchmarkRunnerCore.Run(
-                BenchmarkConverter.TypeToBenchmarks(typeof(LifoSemaphoreBenchmark)),
-                job => new InProcessToolchain(false));
+            BenchmarkRunner.Run<LifoSemaphoreBenchmark>(
+                DefaultConfig.Instance
+                    .AddDiagnoser(MemoryDiagnoser.Default)
+                    .WithOption(ConfigOptions.DisableOptimizationsValidator, true));
         }
 
         [TestCase(1, 1, 500 * 1000)]

--- a/Vostok.Commons.Threading.Tests/Vostok.Commons.Threading.Tests.csproj
+++ b/Vostok.Commons.Threading.Tests/Vostok.Commons.Threading.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>

--- a/Vostok.Commons.Threading/GuidGenerator.cs
+++ b/Vostok.Commons.Threading/GuidGenerator.cs
@@ -11,11 +11,8 @@ namespace Vostok.Commons.Threading
             var bytes = stackalloc byte[16];
             var dst = bytes;
 
-#if NET6_0_OR_GREATER
-            var random = Random.Shared;
-#else
             var random = ThreadSafeRandom.ObtainThreadStaticRandom();
-#endif
+
             for (var i = 0; i < 4; i++)
             {
                 *(int*)dst = random.Next();

--- a/Vostok.Commons.Threading/GuidGenerator.cs
+++ b/Vostok.Commons.Threading/GuidGenerator.cs
@@ -11,7 +11,11 @@ namespace Vostok.Commons.Threading
             var bytes = stackalloc byte[16];
             var dst = bytes;
 
+#if NET6_0_OR_GREATER
+            var random = Random.Shared;
+#else
             var random = ThreadSafeRandom.ObtainThreadStaticRandom();
+#endif
             for (var i = 0; i < 4; i++)
             {
                 *(int*)dst = random.Next();

--- a/Vostok.Commons.Threading/ThreadSafeRandom.cs
+++ b/Vostok.Commons.Threading/ThreadSafeRandom.cs
@@ -67,7 +67,11 @@ namespace Vostok.Commons.Threading
 
         private static Random ObtainRandom()
         {
+#if NET6_0_OR_GREATER
+            return Random.Shared;
+#else
             return random ?? (random = new Random(Guid.NewGuid().GetHashCode()));
+#endif
         }
 
         private static void ThrowArgumentOutOfRangeException(long minValue, long maxValue) =>

--- a/Vostok.Commons.Threading/ThreadSafeRandom.cs
+++ b/Vostok.Commons.Threading/ThreadSafeRandom.cs
@@ -7,8 +7,11 @@ namespace Vostok.Commons.Threading
     [PublicAPI]
     internal static class ThreadSafeRandom
     {
+#if NET6_0_OR_GREATER
+#else
         [ThreadStatic]
         private static Random random;
+#endif
 
         public static double NextDouble()
         {


### PR DESCRIPTION
Here are the results:

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1415 (21H1/May2021Update)
Intel Core i7-4771 CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.101
  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT


|      Method |     Mean |    Error |   StdDev | Allocated |
|------------ |---------:|---------:|---------:|----------:|
| GuidNewGuid | 79.94 ns | 0.396 ns | 0.330 ns |         - |
|    Generate | 50.57 ns | 0.216 ns | 0.168 ns |         - |
| GenerateOld | 55.95 ns | 0.823 ns | 0.770 ns |         - |