### PR TITLE
Optimize guid creation under net6. Yes, again.

### DIFF
--- a/Vostok.Commons.Threading.Tests/GuidGenerator_Benchmarks.cs
+++ b/Vostok.Commons.Threading.Tests/GuidGenerator_Benchmarks.cs
@@ -2,12 +2,14 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using NUnit.Framework;
 
 namespace Vostok.Commons.Threading.Tests
 {
-    [TestFixture]
+    [TestFixture, Explicit]
     public class GuidGenerator_Benchmarks
     {
         [Test]
@@ -15,6 +17,9 @@ namespace Vostok.Commons.Threading.Tests
         {
             BenchmarkRunner.Run<GuidGenerator_Benchmarks>(
                 DefaultConfig.Instance
+                    .AddJob(Job.Default.WithRuntime(ClrRuntime.Net48).WithId(".Net 4.8"))
+                    .AddJob(Job.Default.WithRuntime(CoreRuntime.Core50).WithId(".Net 5.0"))
+                    .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60).WithId(".Net 6.0"))
                     .AddDiagnoser(MemoryDiagnoser.Default)
                     .WithOption(ConfigOptions.DisableOptimizationsValidator, true));
         }
@@ -34,17 +39,25 @@ namespace Vostok.Commons.Threading.Tests
         /*
 // * Summary *
 
-BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1415 (21H1/May2021Update)
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1526 (21H2)
 Intel Core i7-4771 CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
-.NET SDK=6.0.101
-  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
-  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
+.NET SDK=6.0.103
+  [Host]   : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
+  .Net 4.8 : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT
+  .Net 5.0 : .NET 5.0.15 (5.0.1522.11506), X64 RyuJIT
+  .Net 6.0 : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
 
 
-|      Method |     Mean |    Error |   StdDev | Allocated |
-|------------ |---------:|---------:|---------:|----------:|
-| GuidNewGuid | 76.10 ns | 0.623 ns | 0.552 ns |         - |
-|    Generate | 42.97 ns | 0.150 ns | 0.133 ns |         - |
+|      Method |            Runtime |     Mean |
+|------------ |------------------- |---------:|
+| GuidNewGuid | .NET Framework 4.8 | 81.36 ns |
+|    Generate | .NET Framework 4.8 | 55.60 ns |
+|------------ |------------------- |---------:|
+| GuidNewGuid |           .NET 5.0 | 80.87 ns |
+|    Generate |           .NET 5.0 | 45.42 ns |
+|------------ |------------------- |---------:|
+| GuidNewGuid |           .NET 6.0 | 80.38 ns |
+|    Generate |           .NET 6.0 | 15.40 ns |
          */
     }
 }

--- a/Vostok.Commons.Threading/GuidGenerator.cs
+++ b/Vostok.Commons.Threading/GuidGenerator.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+#if NET6_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#else
+#endif
 using JetBrains.Annotations;
 
 namespace Vostok.Commons.Threading
@@ -6,6 +10,10 @@ namespace Vostok.Commons.Threading
     [PublicAPI]
     internal static class GuidGenerator
     {
+#if NET6_0_OR_GREATER
+        [SkipLocalsInit]
+#else
+#endif
         public static unsafe Guid GenerateNotCryptoQualityGuid()
         {
             var bytes = stackalloc byte[16];
@@ -13,11 +21,15 @@ namespace Vostok.Commons.Threading
 
             var random = ThreadSafeRandom.ObtainThreadStaticRandom();
 
+#if NET6_0_OR_GREATER
+            random.NextBytes(new Span<byte>(bytes, 16));
+#else
             for (var i = 0; i < 4; i++)
             {
                 *(int*)dst = random.Next();
                 dst += 4;
             }
+#endif
 
             return *(Guid*)bytes;
         }

--- a/Vostok.Commons.Threading/GuidGenerator.cs
+++ b/Vostok.Commons.Threading/GuidGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 #if NET6_0_OR_GREATER
 using System.Runtime.CompilerServices;
-#else
 #endif
 using JetBrains.Annotations;
 
@@ -12,26 +11,30 @@ namespace Vostok.Commons.Threading
     {
 #if NET6_0_OR_GREATER
         [SkipLocalsInit]
+        public static unsafe Guid GenerateNotCryptoQualityGuid()
+        {
+            var bytes = stackalloc byte[16];
+            
+            Random.Shared.NextBytes(new Span<byte>(bytes, 16));
+
+            return *(Guid*)bytes;
+        }
 #else
-#endif
         public static unsafe Guid GenerateNotCryptoQualityGuid()
         {
             var bytes = stackalloc byte[16];
             var dst = bytes;
 
             var random = ThreadSafeRandom.ObtainThreadStaticRandom();
-
-#if NET6_0_OR_GREATER
-            random.NextBytes(new Span<byte>(bytes, 16));
-#else
+            
             for (var i = 0; i < 4; i++)
             {
                 *(int*)dst = random.Next();
                 dst += 4;
             }
-#endif
 
             return *(Guid*)bytes;
         }
+#endif
     }
 }

--- a/Vostok.Commons.Threading/ThreadSafeRandom.cs
+++ b/Vostok.Commons.Threading/ThreadSafeRandom.cs
@@ -15,22 +15,22 @@ namespace Vostok.Commons.Threading
 
         public static double NextDouble()
         {
-            return ObtainRandom().NextDouble();
+            return ObtainThreadStaticRandom().NextDouble();
         }
 
         public static int Next()
         {
-            return ObtainRandom().Next();
+            return ObtainThreadStaticRandom().Next();
         }
 
         public static int Next(int maxValue)
         {
-            return ObtainRandom().Next(maxValue);
+            return ObtainThreadStaticRandom().Next(maxValue);
         }
 
         public static int Next(int minValue, int maxValue)
         {
-            return ObtainRandom().Next(minValue, maxValue);
+            return ObtainThreadStaticRandom().Next(minValue, maxValue);
         }
 
         public static long Next(long minValue, long maxValue)
@@ -45,7 +45,7 @@ namespace Vostok.Commons.Threading
 
         public static void NextBytes(byte[] buffer)
         {
-            ObtainRandom().NextBytes(buffer);
+            ObtainThreadStaticRandom().NextBytes(buffer);
         }
 
         public static byte[] NextBytes(long size)
@@ -66,9 +66,7 @@ namespace Vostok.Commons.Threading
         /// Be careful! This method returns an instance of the class <see cref="Random"/> with <see cref="ThreadStaticAttribute"/> attribute. It is safe to use this instance only in a synchronous block of code, such as a loop.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Random ObtainThreadStaticRandom() => ObtainRandom();
-
-        private static Random ObtainRandom()
+        public static Random ObtainThreadStaticRandom()
         {
 #if NET6_0_OR_GREATER
             return Random.Shared;


### PR DESCRIPTION
This is the benchmark result:
```
// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1526 (21H2)
Intel Core i7-4771 CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.103
  [Host]   : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  .Net 4.8 : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT
  .Net 5.0 : .NET 5.0.15 (5.0.1522.11506), X64 RyuJIT
  .Net 6.0 : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT


|                      Method |            Runtime |     Mean |
|---------------------------- |------------------- |---------:|
|                 GuidNewGuid | .NET Framework 4.8 | 81.36 ns |
|               GenerateInt32 | .NET Framework 4.8 | 56.41 ns |
|               GenerateInt64 | .NET Framework 4.8 | 55.54 ns |
|               GenerateBytes | .NET Framework 4.8 | 56.11 ns |
| GenerateBytesSkipLocalsInit | .NET Framework 4.8 | 55.60 ns |
|---------------------------- |------------------- |---------:|
|                 GuidNewGuid |           .NET 5.0 | 80.87 ns |
|               GenerateInt32 |           .NET 5.0 | 45.13 ns |
|               GenerateInt64 |           .NET 5.0 | 44.93 ns |
|               GenerateBytes |           .NET 5.0 | 45.01 ns |
| GenerateBytesSkipLocalsInit |           .NET 5.0 | 45.42 ns |
|---------------------------- |------------------- |---------:|
|                 GuidNewGuid |           .NET 6.0 | 80.38 ns |
|               GenerateInt32 |           .NET 6.0 | 46.70 ns |
|               GenerateInt64 |           .NET 6.0 | 23.35 ns |
|               GenerateBytes |           .NET 6.0 | 16.76 ns |
| GenerateBytesSkipLocalsInit |           .NET 6.0 | 15.40 ns |
```

GenerateBytesSkipLocalsInit - this is the new implementation.
GenerateInt32 - the previous one
GuidNewGuid - the pre-previous one

Another methods here are just for fun.